### PR TITLE
Release/v1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@yamamotok/dataobject",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yamamotok/dataobject",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Decorator based JSON serializer and deserializer.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
## Version 1.1.2
- Security fix around external libraries Jest depends on.
- Jest is upgraded from 26 to 27.
- Changes only on `devDependencies`


